### PR TITLE
Reduce chance of name collisions with concurrent harvest workers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,9 @@ RUN $CKAN_HOME/bin/pip install -e git+https://github.com/ioos/ckanext-spatial.gi
 RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-spatial/pip-requirements.txt
 
 # must use this commit or similar as tagged versions cause "Add harvests" page
-# to display no fields
-RUN $CKAN_HOME/bin/pip install -e git+https://github.com/ckan/ckanext-harvest.git@7f506913f8e789#egg=ckanext-harvest
+# to display no fields.  Harvests may also fail to initialize, delete, or run
+# possibly due to breaking API changes.
+RUN $CKAN_HOME/bin/pip install -e git+https://github.com/benjwadams/ckanext-harvest.git@race_condition_graceful_death_old#egg=ckanext-harvest
 RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-harvest/pip-requirements.txt
 
 RUN $CKAN_HOME/bin/pip install -e git+https://github.com/geopython/pycsw.git@1.10.5#egg=pycsw

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-spatial/pip-requirement
 # must use this commit or similar as tagged versions cause "Add harvests" page
 # to display no fields.  Harvests may also fail to initialize, delete, or run
 # possibly due to breaking API changes.
-RUN $CKAN_HOME/bin/pip install -e git+https://github.com/benjwadams/ckanext-harvest.git@race_condition_graceful_death_old#egg=ckanext-harvest
+RUN $CKAN_HOME/bin/pip install -e git+https://github.com/ioos/ckanext-harvest.git@catalog_compat#egg=ckanext-harvest
 RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/ckanext-harvest/pip-requirements.txt
 
 RUN $CKAN_HOME/bin/pip install -e git+https://github.com/geopython/pycsw.git@1.10.5#egg=pycsw

--- a/contrib/my_init.d/50_configure
+++ b/contrib/my_init.d/50_configure
@@ -47,7 +47,7 @@ write_config () {
       "ckan.plugins = stats text_view image_view recline_view spatial_metadata spatial_query harvest ckan_harvester csw_harvester waf_harvester ioos_theme ioos_waf"
   $CKAN_HOME/bin/paster --plugin=ckan config-tool $CONFIG ckan.extra_resource_fields=guid
 
-  sed -i -e "s/\[loggers\]/\n## Message Queue\n\nckan.harvest.mq.type = redis\nckan.harvest.mq.hostname = ${REDIS_HOST}\nckan.harvest.mq.port = ${REDIS_PORT}\nckan.harvest.mq.redis_db = ${REDIS_DB}\n\n## Spatial\n\nckan.spatial.validator.profiles = iso19139ngdc\nckan.spatial.search_backend = solr\nckan.spatial.harvest.continue_on_validation_errors = true\n[loggers]/" "$CONFIG"
+  sed -i -e "s/\[loggers\]/\n## Message Queue\n\nckan.harvest.mq.type = redis\nckan.harvest.mq.hostname = ${REDIS_HOST}\nckan.harvest.mq.port = ${REDIS_PORT}\nckan.harvest.mq.redis_db = ${REDIS_DB}\nckan.harvest.dup_append_type = random-hex\n\n## Spatial\n\nckan.spatial.validator.profiles = iso19139ngdc\nckan.spatial.search_backend = solr\nckan.spatial.harvest.continue_on_validation_errors = true\n[loggers]/" "$CONFIG"
   # Enable debug mode
   if [ -n $CKAN_DEBUG ]; then
       sed -i -e "s/debug = false/debug = ${CKAN_DEBUG}/" "$CONFIG"


### PR DESCRIPTION
Reduces the chances of collisions for harvesters concurrently processing
datasets where the name is the same.  By default, a sequential number is
appended by CKAN in order to prevent name collisions on the unique name field.
However, if several workers attempt to process a dataset of the same
name, they can end up using the same name, which will cause an SQL
duplicate error.  By appending a random hex string instead, the likelihood of a
collision is greatly reduced.  In the event a collision still does
happen, an error is logged and the worker continues processing other datasets
from the queue.  Should fix ckan_catalog/#95.