### PR TITLE
Updated keywords in default.cfg with IOOS core variables

### DIFF
--- a/contrib/config/pycsw/default.cfg
+++ b/contrib/config/pycsw/default.cfg
@@ -14,8 +14,7 @@ allowed_ips = 127.0.0.1
 [metadata:main]
 identification_title = US IOOS CS-W Geospatial Catalogue (pycsw)
 identification_abstract = The IOOS Catalog is the master inventory of IOOS DMAC datasets and data access services.
-identification_keywords = IOOS, ocean observations, forecasts, real-time, DMAC, SOS, OPeNDAP,time,latitude,longitude,projection_y_coordinate,pro
-jection_x_coordinate,Aquarius/SAC-D Mission,NASA Jet Propulsion Laboratory, Physical Oceanogra,sea_water_temperature,air_temperature,depth,eastward_wind,northward_wind,wind_speed,Oceans > Ocean Winds > Surface Winds,sea_surface_salinity,northward_sea_water_velocity,sea_water_salinity,eastward_sea_water_velocity,sea_ice_area_fraction,lwe_thickness_of_precipitation_amount
+identification_keywords = IOOS,ocean observations,forecasts,real-time,DMAC,SOS,OPeNDAP,THREDDS,ERDDAP,time,latitude,longitude,Acidity,Bathymetry,Bottom Character,Colored Dissolved Organic Matter,Contaminants,Dissolved Nutrients,Dissolved Oxygen,Fish Abundance,Fish Species,Heat Flux,Ice Distribution,Ocean Color,Optical Properties,Partial Pressure of CO2,Pathogens,Phytoplankton Species,Salinity,Sea Level,Stream Flow,Surface Currents,Surface Waves,Temperature,Total Suspended Matter,Wind Speed and Direction,Zooplankton Abundance,Zooplankton Species
 identification_keywords_type = theme
 identification_fees = None
 identification_accessconstraints = None
@@ -50,5 +49,3 @@ conformity_service = notEvaluated
 contact_name = Organization Name
 contact_email = Email Address
 temp_extent = YYYY-MM-DD/YYYY-MM-DD
-
-


### PR DESCRIPTION
Let's give this a try.  Updated the keywords from the 'IOOS Core Variables' [here](http://www.iooc.us/ocean-observations/variables/core-ioos-variables/)... hopefully those are still accurate.   

Perhaps the existing line split is causing the pycsw error as well. 