### PR TITLE
Reduce harvester count to 1

### DIFF
--- a/contrib/supervisor/conf.d/harvester.conf
+++ b/contrib/supervisor/conf.d/harvester.conf
@@ -3,7 +3,7 @@ command=%(ENV_CKAN_HOME)s/bin/paster --plugin=ckanext-harvest harvester -c %(ENV
 process_name=%(program_name)s_%(process_num)02d
 autostart=true
 autorestart=false
-numprocs=4
+numprocs=1
 directory=%(ENV_CKAN_HOME)s
 stopsignal=INT
 stdout_logfile=/var/log/gather_consumer_%(process_num)02d.log
@@ -15,7 +15,7 @@ command=%(ENV_CKAN_HOME)s/bin/paster --plugin=ckanext-harvest harvester -c %(ENV
 process_name=%(program_name)s_%(process_num)02d
 autostart=true
 autorestart=false
-numprocs=4
+numprocs=1
 directory=%(ENV_CKAN_HOME)s
 stopsignal=INT
 stdout_logfile=/var/log/fetch_consumer_%(process_num)02d.log


### PR DESCRIPTION
Harvesters use a huge amount of system resources, around 500 MiB a
piece.. Also, there's still an outstanding bug that crashes the
harvesters if two datasets have similar metadata. So to reduce system
burden and prevent unwanted crashes, we'll reduce the count to 1 for the
time being