### PR TITLE
Make Google Analytics optional

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN $CKAN_HOME/bin/pip install -r $CKAN_HOME/src/pycsw/requirements.txt
 
 RUN "$CKAN_HOME/bin/pip" install --upgrade pip
 
+# optional, but ships with the image by default
 RUN "$CKAN_HOME/bin/pip" install -e git+https://github.com/ckan/ckanext-googleanalytics.git#egg=ckanext-googleanalytics && \
     "$CKAN_HOME/bin/pip" install -r "$CKAN_HOME/src/ckanext-googleanalytics/requirements.txt"
 

--- a/contrib/my_init.d/50_configure
+++ b/contrib/my_init.d/50_configure
@@ -20,6 +20,9 @@
 : ${MAIL_PASSWORD:=}
 : ${MAIL_FROM:=admin.ioos.us}
 : ${FEEDBACK_RECIPIENTS:=}
+# if GA_ENABLED is set, you must also set the variables
+# GA_ID, GA_ACCOUNT, GA_USERNAME, and GA_PASSWORD
+${GA_ENABLED:=false}
 
 set -eux
 
@@ -46,6 +49,11 @@ write_config () {
   "$CKAN_HOME"/bin/paster --plugin=ckan config-tool "$CONFIG" -s server:main \
                                                 -e 'port = 8080'
 
+
+  extra_plugins=''
+
+  [[ "$GA_ENABLED" = true ]] && extra_plugins="$extra_plugins googleanalytics"
+
   "$CKAN_HOME"/bin/paster --plugin=ckan config-tool "$CONFIG" -e \
       "sqlalchemy.url = ${DATABASE_URL}" \
       "solr_url = ${SOLR_URL}" \
@@ -55,7 +63,7 @@ write_config () {
       "email_to = disabled@example.com" \
       "error_email_from = ckan@$(hostname -f)" \
       "ckan.site_url = ${CKAN_SERVER_NAME}" \
-      "ckan.plugins = stats text_view image_view recline_view spatial_metadata spatial_query harvest ckan_harvester csw_harvester waf_harvester ioos_theme ioos_waf googleanalytics"
+      "ckan.plugins = stats text_view image_view recline_view spatial_metadata spatial_query harvest ckan_harvester csw_harvester waf_harvester ioos_theme ioos_waf${extra_plugins}"
   $CKAN_HOME/bin/paster --plugin=ckan config-tool $CONFIG ckan.extra_resource_fields=guid
   $CKAN_HOME/bin/paster --plugin=ckan config-tool $CONFIG "ckan.ioos_theme.pycsw_config=${CKAN_HOME}/src/pycsw/default.cfg"
   $CKAN_HOME/bin/paster --plugin=ckan config-tool $CONFIG "ckan.cors.origin_allow_all = true"
@@ -87,11 +95,13 @@ write_config () {
   sed -i -e "s/\[loggers\]/\n## Message Queue\n\nckan.harvest.mq.type = redis\nckan.harvest.mq.hostname = ${REDIS_HOST}\nckan.harvest.mq.port = ${REDIS_PORT}\nckan.harvest.mq.redis_db = ${REDIS_DB}\nckan.harvest.dup_append_type = random-hex\n\n## Spatial\n\nckan.spatial.validator.profiles = iso19139ngdc\nckanext.spatial.search_backend = solr\nckan.spatial.harvest.continue_on_validation_errors = true\n[loggers]/" "$CONFIG"
 
 # add GA data
-"$CKAN_HOME/bin/paster" --plugin=ckan config-tool "$CONFIG" "googleanalytics.id=${GA_ID}" \
-        "googleanalytics.account=${GA_ACCOUNT}" \
-        "googleanalytics.username=${GA_USERNAME}" \
-        "googleanalytics.password=${GA_PASSWORD}" \
-        "googleanalytics.track_events=true"
+if [[ "$GA_ENABLED" = true ]]; then
+    "$CKAN_HOME/bin/paster" --plugin=ckan config-tool "$CONFIG" "googleanalytics.id=${GA_ID}" \
+            "googleanalytics.account=${GA_ACCOUNT}" \
+            "googleanalytics.username=${GA_USERNAME}" \
+            "googleanalytics.password=${GA_PASSWORD}" \
+            "googleanalytics.track_events=true"
+fi
 
   # Enable debug mode
   if [ -n $CKAN_DEBUG ]; then


### PR DESCRIPTION
Makes the use of the ckanext-googleanalytics plugin optional, defaulting
to not using the plugin.  Use `GA_ENABLED=true` in the env file to
enable.